### PR TITLE
Add IB support

### DIFF
--- a/LLARingSpinnerView/LLARingSpinnerView.m
+++ b/LLARingSpinnerView/LLARingSpinnerView.m
@@ -29,6 +29,14 @@ static NSString *kLLARingSpinnerAnimationKey = @"llaringspinnerview.rotation";
     return self;
 }
 
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    if (self = [super initWithCoder:aDecoder]) {
+        [self.layer addSublayer:self.progressLayer];
+    }
+    return self;
+}
+
 - (void)layoutSubviews {
     [super layoutSubviews];
 


### PR DESCRIPTION
Adds support for subclassing a UIView to LLARingSpinnerView in InterfaceBuilder by implementing the required `-initWithCoder:` method.
